### PR TITLE
deploy.sh not working for C#

### DIFF
--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -43,7 +43,7 @@ if [ -f output.json ]; then
     HOST_NAME=$(echo "$DISCOVERY_URL" | sed -e 's|^https://||' -e 's|/discovery$||')
 
     # Generate the PROJECT_CONNECTION_STRING
-    PROJECT_CONNECTION_STRING="\"$HOST_NAME;$SUBSCRIPTION_ID;$RESOURCE_GROUP_NAME;$AI_PROJECT_NAME\""
+    PROJECT_CONNECTION_STRING="$HOST_NAME;$SUBSCRIPTION_ID;$RESOURCE_GROUP_NAME;$AI_PROJECT_NAME"
 
     ENV_FILE_PATH="../src/python/workshop/.env"
 
@@ -52,7 +52,7 @@ if [ -f output.json ]; then
 
     # Write to the .env file
     {
-      echo "PROJECT_CONNECTION_STRING=$PROJECT_CONNECTION_STRING"
+      echo "PROJECT_CONNECTION_STRING=\"$PROJECT_CONNECTION_STRING\""
       echo "BING_CONNECTION_NAME=\"groundingwithbingsearch\""
       echo "MODEL_DEPLOYMENT_NAME=\"$MODEL_NAME\""
     } > "$ENV_FILE_PATH"


### PR DESCRIPTION
## Description

As a prerequisite, 

- Select **Self-Guide Learners**
- Running on GitHub Codespaces.
- Selected **Automated deployment** in the ["Deploy the Azure Resources" section of Getting Started](https://microsoft.github.io/build-your-first-agent-with-azure-ai-agent-service-workshop/getting-started/#deploy-the-azure-resources).

After creating Azure resources using deploy.sh, the C# code does not run due to the following error.


### Error

```
Unhandled exception. System.UriFormatException: Invalid URI: The hostname could not be parsed.
   at System.Uri.CreateThis(String uri, Boolean dontEscape, UriKind uriKind, UriCreationOptions& creationOptions)
   at System.Uri..ctor(String uriString)
   at Azure.AI.Projects.AIProjectClient..ctor(String connectionString, TokenCredential credential, AIProjectClientOptions options)
   at Azure.AI.Projects.AIProjectClient..ctor(String connectionString, TokenCredential credential)
   at Program.<Main>$(String[] args) in /workspaces/build-your-first-agent-with-azure-ai-agent-service-workshop/src/csharp/workshop/AgentWorkshop.Client/Program.cs:line 14
   at Program.<Main>(String[] args)
```

![image](https://github.com/user-attachments/assets/5afe842c-4222-4f42-b2cc-083884616b3e)


## Cause

When I checked `dotnet user-secrets list`, the value for `onnectionStrings:AiAgentService` had unnecessary double quotes, as shown below

![image](https://github.com/user-attachments/assets/e1128d45-82ea-412b-b0ed-3a881a9e0f3b)

So, it works correctly by applying this fix to deploy.sh.